### PR TITLE
Fixing build.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,7 @@
 			"cflags_cc": ["-Wall", "-std=c++11"],
 			"cflags!": [ "-fno-exceptions" ],
 			"cflags_cc!": [ "-fno-exceptions" ],
+			"libraries": ["-lmnl"],
 			"ldflags": ["-lmnl", "-std=c++11"],
 			"include_dirs" : [
 				"<!(node -e \"require('nan')\")", 


### PR DESCRIPTION
Node-gyp doesn't support "ldflags", "libraries" is the right one.

It is weird that it was working like that for some time without that fix, then start to fail - probably ldflags has some support in the past.

Will you PR your changes to derfel's repo so we could use `npm install netlink-notify` directly?